### PR TITLE
docs(auth): add OpenID Connect token placeholders and OPENID_EXPOSE_SUB_COOKIE documentation

### DIFF
--- a/pages/docs/configuration/authentication/OAuth2-OIDC/token-reuse.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/token-reuse.mdx
@@ -114,6 +114,9 @@ OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE=user.read
 
 # Logout Configuration
 OPENID_USE_END_SESSION_ENDPOINT=true
+
+# Cross-origin OAuth Callback Support (optional, independent of OPENID_REUSE_TOKENS)
+# OPENID_EXPOSE_SUB_COOKIE=true
 ```
 
 ## Additional Configuration Options
@@ -124,6 +127,7 @@ OPENID_USE_END_SESSION_ENDPOINT=true
 - `OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED`: Enables on-behalf-of flow for user info (Azure-specific)
 - `OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE`: Scope for user info in on-behalf-of flow (Azure-specific)
 - `OPENID_USE_END_SESSION_ENDPOINT`: Enables use of the end session endpoint for logout
+- `OPENID_EXPOSE_SUB_COOKIE`: Exposes a JWT-signed cookie containing the OpenID `sub` claim with `sameSite=lax`. This enables cross-origin OAuth callback flows (e.g., AWS Bedrock AgentCore 3LO). Can be used independently of `OPENID_REUSE_TOKENS`.
 
 ## Security Considerations
 

--- a/pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
@@ -490,6 +490,33 @@ headers:
   X-Message-ID: "{{LIBRECHAT_BODY_MESSAGEID}}"
 ```
 
+**Available OpenID Token Placeholders:**
+
+These placeholders are available when using OpenID Connect authentication. They extract values from the OpenID tokens stored in the user's session.
+
+| Placeholder | Description |
+|-------------|-------------|
+| `{{LIBRECHAT_OPENID_TOKEN}}` | OpenID access token (generic alias for ACCESS_TOKEN) |
+| `{{LIBRECHAT_OPENID_ACCESS_TOKEN}}` | OpenID access token |
+| `{{LIBRECHAT_OPENID_ID_TOKEN}}` | OpenID ID token |
+| `{{LIBRECHAT_OPENID_USER_ID}}` | User ID from OpenID claims (sub claim or openidId) |
+| `{{LIBRECHAT_OPENID_USER_EMAIL}}` | User email from OpenID claims |
+| `{{LIBRECHAT_OPENID_USER_NAME}}` | User name from OpenID claims |
+| `{{LIBRECHAT_OPENID_EXPIRES_AT}}` | Token expiration timestamp (Unix epoch seconds) |
+
+<Callout type="info" title="OpenID Token Availability">
+These placeholders require OpenID Connect authentication to be configured. The token values are extracted from the `federatedTokens` or `openidTokens` properties on the user object, which are populated during the OpenID authentication flow.
+</Callout>
+
+**Example using OpenID token placeholders:**
+
+```yaml filename="endpoints / custom / headers with OpenID tokens"
+headers:
+  Authorization: "Bearer {{LIBRECHAT_OPENID_ACCESS_TOKEN}}"
+  X-ID-Token: "{{LIBRECHAT_OPENID_ID_TOKEN}}"
+  X-User-Sub: "{{LIBRECHAT_OPENID_USER_ID}}"
+```
+
 ## directEndpoint
 
 **Key:**


### PR DESCRIPTION
## What

Add comprehensive documentation for OpenID Connect authentication features, including the new `OPENID_EXPOSE_SUB_COOKIE` configuration option and seven available OpenID token placeholders for use in custom endpoint headers.

## Why

Developers need clear guidance on:
- How to use OpenID tokens in custom endpoint configurations
- The cross-origin OAuth callback support capabilities
- The new OPENID_EXPOSE_SUB_COOKIE option for advanced authentication scenarios

## Changes

### token-reuse.mdx
- Added `OPENID_EXPOSE_SUB_COOKIE` environment variable documentation (line 119)
- Documented this option exposes a JWT-signed cookie containing the OpenID `sub` claim
- Explains cross-origin OAuth callback flows support (e.g., AWS Bedrock AgentCore 3LO)
- Added to "Additional Configuration Options" section with full description (line 130)

### custom_endpoint.mdx
- Added "Available OpenID Token Placeholders" table (lines 493-506) with seven placeholders:
  - `{{LIBRECHAT_OPENID_TOKEN}}` - OpenID access token (generic alias)
  - `{{LIBRECHAT_OPENID_ACCESS_TOKEN}}` - OpenID access token
  - `{{LIBRECHAT_OPENID_ID_TOKEN}}` - OpenID ID token
  - `{{LIBRECHAT_OPENID_USER_ID}}` - User ID from OpenID claims
  - `{{LIBRECHAT_OPENID_USER_EMAIL}}` - User email from OpenID claims
  - `{{LIBRECHAT_OPENID_USER_NAME}}` - User name from OpenID claims
  - `{{LIBRECHAT_OPENID_EXPIRES_AT}}` - Token expiration timestamp
- Added informational callout explaining token availability requirements (lines 507-509)
- Added practical usage example showing how to use OpenID tokens in custom headers (lines 511-518)

## Test plan

- Verify documentation renders correctly in the docs site
- Confirm all placeholder references are accurate
- Review that examples are syntactically valid YAML
- Cross-reference with existing OpenID Connect documentation for consistency

Generated with Claude Code